### PR TITLE
タスク一覧スクリーンのデザインを用意

### DIFF
--- a/lib/components/tasks/task_card.dart
+++ b/lib/components/tasks/task_card.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:board/models/task_model.dart';
+import 'package:board/state/book_route_delegate_state.dart';
+
+class TaskCard extends ConsumerWidget {
+  const TaskCard({
+    Key? key,
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.dueDateTime,
+    required this.status,
+  }) : super(key: key);
+
+  final String id;
+  final String title;
+  final String description;
+  final DateTime dueDateTime;
+  final String status;
+
+  Color? statusColor() {
+    if (status == taskStatusTodo) {
+      return Colors.lime[100];
+    }
+
+    if (status == taskStatusDone) {
+      return Colors.brown[100];
+    }
+
+    return Colors.amber;
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 8.0),
+        child: Column(
+          children: [
+            Row(
+              children: <Widget>[
+                Expanded(
+                  flex: 1,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        title,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16.0,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Container(
+                  padding: const EdgeInsets.all(6.0),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(10),
+                    color: statusColor(),
+                  ),
+                  child: Text(status),
+                ),
+              ],
+            ),
+            Container(
+              margin: const EdgeInsets.symmetric(vertical: 16.0),
+              child: Text(
+                description,
+                style: TextStyle(color: Colors.black.withOpacity(0.6)),
+              ),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                ElevatedButton(
+                  child: const Text('詳細へ'),
+                  onPressed: () {
+                    ref.read(bookRouteDelegateProvider).handleBookTapped(id);
+                  },
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/components/tasks/tasks_doing_list.dart
+++ b/lib/components/tasks/tasks_doing_list.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:board/components/tasks/task_card.dart';
+import 'package:board/state/tasks_state.dart';
+
+class TasksDoingList extends ConsumerWidget {
+  const TasksDoingList({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tasks = ref.watch(tasksProvider);
+
+    return ListView.builder(
+      itemCount: tasks.length,
+      padding: const EdgeInsets.only(bottom: 60.0),
+      itemBuilder: (BuildContext context, int index) {
+        return TaskCard(
+          id: tasks[index].id,
+          title: tasks[index].title,
+          description: tasks[index].description,
+          dueDateTime: tasks[index].dueDateTime,
+          status: tasks[index].status,
+        );
+      },
+    );
+  }
+}

--- a/lib/components/tasks/tasks_done_list.dart
+++ b/lib/components/tasks/tasks_done_list.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:board/components/tasks/task_card.dart';
+import 'package:board/state/tasks_state.dart';
+
+class TasksDoneList extends ConsumerWidget {
+  const TasksDoneList({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tasks = ref.watch(tasksProvider);
+
+    return ListView.builder(
+      itemCount: tasks.length,
+      padding: const EdgeInsets.only(bottom: 60.0),
+      itemBuilder: (BuildContext context, int index) {
+        return TaskCard(
+          id: tasks[index].id,
+          title: tasks[index].title,
+          description: tasks[index].description,
+          dueDateTime: tasks[index].dueDateTime,
+          status: tasks[index].status,
+        );
+      },
+    );
+  }
+}

--- a/lib/components/tasks/tasks_todo_list.dart
+++ b/lib/components/tasks/tasks_todo_list.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:board/components/tasks/task_card.dart';
+import 'package:board/state/tasks_state.dart';
+
+class TasksTodoList extends ConsumerWidget {
+  const TasksTodoList({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tasks = ref.watch(tasksProvider);
+
+    return ListView.builder(
+      itemCount: tasks.length,
+      padding: const EdgeInsets.only(bottom: 60.0),
+      itemBuilder: (BuildContext context, int index) {
+        return TaskCard(
+          id: tasks[index].id,
+          title: tasks[index].title,
+          description: tasks[index].description,
+          dueDateTime: tasks[index].dueDateTime,
+          status: tasks[index].status,
+        );
+      },
+    );
+  }
+}

--- a/lib/models/task_model.dart
+++ b/lib/models/task_model.dart
@@ -1,0 +1,20 @@
+import 'package:uuid/uuid.dart';
+
+const String taskStatusTodo = 'TODO';
+const String taskStatusDoing = 'DOING';
+const String taskStatusDone = 'DONE';
+
+class TaskModel {
+  TaskModel({
+    required this.title,
+    required this.description,
+    required this.dueDateTime,
+    required this.status,
+  });
+
+  final String id = const Uuid().v4();
+  final String title;
+  final String description;
+  final DateTime dueDateTime;
+  final String status;
+}

--- a/lib/models/task_status_tab_model.dart
+++ b/lib/models/task_status_tab_model.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class TaskStatusTabModel {
+  const TaskStatusTabModel({required this.title, required this.icon});
+
+  final String title;
+  final IconData icon;
+}
+
+const List<TaskStatusTabModel> taskStatusTabs = [
+  TaskStatusTabModel(title: 'TODO', icon: Icons.task),
+  TaskStatusTabModel(title: 'DOING', icon: Icons.directions_bike),
+  TaskStatusTabModel(title: 'DONE', icon: Icons.directions_boat),
+];

--- a/lib/screens/tasks/tasks_index.dart
+++ b/lib/screens/tasks/tasks_index.dart
@@ -1,4 +1,22 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:board/components/tasks/tasks_todo_list.dart';
+import 'package:board/components/tasks/tasks_doing_list.dart';
+import 'package:board/components/tasks/tasks_done_list.dart';
+
+class TaskStatusTabModel {
+  const TaskStatusTabModel({required this.title, required this.icon});
+
+  final String title;
+  final IconData icon;
+}
+
+const List<TaskStatusTabModel> taskStatusTabs = [
+  TaskStatusTabModel(title: 'TODO', icon: Icons.task),
+  TaskStatusTabModel(title: 'DOING', icon: Icons.directions_bike),
+  TaskStatusTabModel(title: 'DONE', icon: Icons.directions_boat),
+];
 
 class TasksIndexScreen extends StatelessWidget {
   const TasksIndexScreen({Key? key}) : super(key: key);
@@ -18,12 +36,41 @@ class TasksIndexScreen extends StatelessWidget {
         tooltip: 'Increment',
         child: const Icon(Icons.add),
       ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: const <Widget>[
-            Text('task screen'),
-          ],
+      body: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 8.0),
+        child: DefaultTabController(
+          length: taskStatusTabs.length,
+          initialIndex: 0,
+          child: Column(
+            children: <Widget>[
+              Container(
+                margin: const EdgeInsets.symmetric(vertical: 16.0),
+                decoration: const BoxDecoration(
+                  border: Border(
+                    bottom: BorderSide(color: Colors.grey, width: 0.5),
+                  ),
+                ),
+                child: TabBar(
+                  labelColor: Colors.amber,
+                  unselectedLabelColor: Colors.black,
+                  tabs: taskStatusTabs.map((TaskStatusTabModel taskStatusTab) {
+                    return Tab(
+                      text: taskStatusTab.title,
+                    );
+                  }).toList(),
+                ),
+              ),
+              const Expanded(
+                child: TabBarView(
+                  children: <Widget>[
+                    TasksTodoList(),
+                    TasksDoingList(),
+                    TasksDoneList(),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/tasks/tasks_index.dart
+++ b/lib/screens/tasks/tasks_index.dart
@@ -29,7 +29,7 @@ class TasksIndexScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('タスク画面'),
+        title: const Text('タスク'),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: onPressed,

--- a/lib/state/tasks_state.dart
+++ b/lib/state/tasks_state.dart
@@ -1,0 +1,9 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:board/viewmodels/task_change_notifier.dart';
+import 'package:board/models/task_model.dart';
+
+final tasksProvider =
+    StateNotifierProvider<TaskChangeNotifier, List<TaskModel>>(
+  (ref) => TaskChangeNotifier(),
+);

--- a/lib/viewmodels/task_change_notifier.dart
+++ b/lib/viewmodels/task_change_notifier.dart
@@ -1,0 +1,29 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:board/models/task_model.dart';
+
+class TaskChangeNotifier extends StateNotifier<List<TaskModel>> {
+  TaskChangeNotifier() : super(_tasks);
+
+  static final List<TaskModel> _tasks = [
+    TaskModel(
+      title: "titletitletitletitletitletitletitletitle",
+      description:
+          "descriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescription",
+      dueDateTime: DateTime.now(),
+      status: taskStatusTodo,
+    ),
+    TaskModel(
+      title: "title2",
+      description: "description2",
+      dueDateTime: DateTime.now(),
+      status: taskStatusDoing,
+    ),
+    TaskModel(
+      title: "title3",
+      description: "description3",
+      dueDateTime: DateTime.now(),
+      status: taskStatusDone,
+    )
+  ];
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -50,6 +50,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -198,6 +205,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  uuid:
+    dependency: "direct main"
+    description:
+      name: uuid
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.5"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   flutter_hooks: 0.18.0
   hooks_riverpod: 1.0.0
   app_settings: 4.1.1
+  uuid: 3.0.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## WHY
 - タスク一覧スクリーンについて一旦デザインだけ用意してみる。

## WHAT
 - タスクのIDを決めるのに `uuid` パッケージをインストール。
 - タスクモデルとタスクを表示するカードウィジェットを用意。
 - 要件の中に一覧画面の中にTODO / DOING / DONEの3つを分けられるように上にタブを用意。

## NEXT ACTION(やらなかったこと)
 - Navigator 2.0を使った詳細ページへの遷移
 - sqliteからのデータ取得