### PR TITLE
nagivator2.0を使っての画面遷移

### DIFF
--- a/lib/components/tasks/task_card.dart
+++ b/lib/components/tasks/task_card.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'package:board/models/task_model.dart';
-import 'package:board/state/book_route_delegate_state.dart';
+import 'package:board/state/board_route_delegate_state.dart';
 
 class TaskCard extends ConsumerWidget {
   const TaskCard({
@@ -80,7 +80,7 @@ class TaskCard extends ConsumerWidget {
                 ElevatedButton(
                   child: const Text('詳細へ'),
                   onPressed: () {
-                    ref.read(bookRouteDelegateProvider).handleBookTapped(id);
+                    ref.read(boardRouteDelegateProvider).setModeToDetails(id);
                   },
                 ),
               ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,23 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import 'package:board/screens/board_home_screen.dart';
+import 'package:board/state/board_route_delegate_state.dart';
+import 'package:board/router/board_route_information_parser.dart';
 
 void main() {
   runApp(const ProviderScope(child: MyApp()));
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends ConsumerWidget {
   const MyApp({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
+  Widget build(BuildContext context, WidgetRef ref) {
+    final provider = ref.read(boardRouteDelegateProvider);
+
+    return MaterialApp.router(
       title: 'Board App',
       theme: ThemeData(
         primarySwatch: Colors.amber,
       ),
-      home: BoardHomeScreen(),
+      routerDelegate: provider,
+      routeInformationParser: BoardRouteInformationParser(),
     );
   }
 }

--- a/lib/router/board_route_information_parser.dart
+++ b/lib/router/board_route_information_parser.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+import 'package:board/router/board_route_path.dart';
+
+class BoardRouteInformationParser
+    extends RouteInformationParser<BoardRoutePath> {
+  @override
+  Future<BoardRoutePath> parseRouteInformation(
+    RouteInformation routeInformation,
+  ) async {
+    final uri = Uri.parse(routeInformation.location ?? '');
+    if (uri.pathSegments.isEmpty) {
+      return BoardRoutePath.home();
+    }
+
+    if (uri.pathSegments.length == 2) {
+      if (uri.pathSegments[0] != 'tasks') {
+        return BoardRoutePath.notFound();
+      }
+
+      final taskId = uri.pathSegments[1];
+      if (taskId == 'create') {
+        BoardRoutePath.create();
+      }
+
+      return BoardRoutePath.details(taskId);
+    }
+
+    return BoardRoutePath.notFound();
+  }
+
+  @override
+  RouteInformation? restoreRouteInformation(BoardRoutePath configuration) {
+    if (configuration.isNotFound) {
+      return const RouteInformation(location: '/404');
+    }
+    if (configuration.isHomePage) {
+      return const RouteInformation(location: '/');
+    }
+    if (configuration.isDetailsPage) {
+      return RouteInformation(location: '/tasks/${configuration.id}');
+    }
+    if (configuration.isCreatePage) {
+      return const RouteInformation(location: '/tasks/create');
+    }
+
+    return null;
+  }
+}

--- a/lib/router/board_route_path.dart
+++ b/lib/router/board_route_path.dart
@@ -1,0 +1,26 @@
+class BoardRoutePath {
+  final String? id;
+  final String mode;
+
+  BoardRoutePath.home()
+      : id = null,
+        mode = 'list';
+
+  BoardRoutePath.details(this.id) : mode = 'details';
+
+  BoardRoutePath.create()
+      : id = null,
+        mode = 'create';
+
+  BoardRoutePath.notFound()
+      : id = null,
+        mode = 'not-found';
+
+  bool get isHomePage => mode == 'list';
+
+  bool get isDetailsPage => mode == 'details';
+
+  bool get isNotFound => mode == 'not-found';
+
+  bool get isCreatePage => mode == 'create';
+}

--- a/lib/router/board_router_delegate.dart
+++ b/lib/router/board_router_delegate.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+
+import 'package:board/screens/tasks/tasks_detail.dart';
+import 'package:board/screens/tasks/tasks_create.dart';
+import 'package:board/screens/board_home_screen.dart';
+import 'package:board/screens/not_found_screen.dart';
+import 'package:board/router/board_route_path.dart';
+
+class BoardRouterDelegate extends RouterDelegate<BoardRoutePath>
+    with ChangeNotifier, PopNavigatorRouterDelegateMixin<BoardRoutePath> {
+  @override
+  final GlobalKey<NavigatorState> navigatorKey;
+
+  get selectedTaskId => _selectedTaskId;
+
+  String? _selectedTaskId;
+  String _mode = 'list';
+
+  BoardRouterDelegate() : navigatorKey = GlobalKey<NavigatorState>();
+
+  @override
+  BoardRoutePath get currentConfiguration {
+    if (_mode == 'not-found') {
+      return BoardRoutePath.notFound();
+    }
+
+    if (_mode == 'list') {
+      return BoardRoutePath.home();
+    }
+
+    if (_mode == 'create') {
+      return BoardRoutePath.create();
+    }
+
+    return BoardRoutePath.details(_selectedTaskId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Navigator(
+      key: navigatorKey,
+      pages: [
+        MaterialPage(
+          key: const ValueKey('BoardHomeScreen'),
+          child: BoardHomeScreen(),
+        ),
+        if (_mode == 'create')
+          const MaterialPage(
+            key: ValueKey('TasksCreateScreen'),
+            child: TasksCreateScreen(),
+          ),
+        if (_mode == 'details')
+          MaterialPage(child: TasksDetailScreen(id: _selectedTaskId!)),
+        if (_mode == 'not-found')
+          const MaterialPage(
+            key: ValueKey('NotFoundScreen'),
+            child: NotFoundScreen(),
+          )
+      ],
+      onPopPage: (route, result) {
+        if (!route.didPop(result)) {
+          return false;
+        }
+
+        _selectedTaskId = null;
+        _mode = 'list';
+        notifyListeners();
+
+        return true;
+      },
+    );
+  }
+
+  @override
+  Future<void> setNewRoutePath(BoardRoutePath configuration) async {
+    if (configuration.isHomePage) {
+      _mode = 'list';
+      _selectedTaskId = null;
+      return;
+    }
+
+    if (configuration.isDetailsPage) {
+      _mode = 'details';
+      _selectedTaskId = configuration.id;
+      return;
+    }
+
+    if (configuration.isCreatePage) {
+      _mode = 'create';
+      _selectedTaskId = null;
+      return;
+    }
+
+    _selectedTaskId = null;
+    _mode = 'not-found';
+    notifyListeners();
+  }
+
+  void setModeToDetails(String taskId) {
+    _mode = 'details';
+    _selectedTaskId = taskId;
+    notifyListeners();
+  }
+
+  void setModeToCreate() {
+    _mode = 'create';
+    notifyListeners();
+  }
+}

--- a/lib/router/board_router_delegate.dart
+++ b/lib/router/board_router_delegate.dart
@@ -20,8 +20,8 @@ class BoardRouterDelegate extends RouterDelegate<BoardRoutePath>
 
   @override
   BoardRoutePath get currentConfiguration {
-    if (_mode == 'not-found') {
-      return BoardRoutePath.notFound();
+    if (_mode == 'details') {
+      return BoardRoutePath.details(_selectedTaskId);
     }
 
     if (_mode == 'list') {
@@ -32,7 +32,7 @@ class BoardRouterDelegate extends RouterDelegate<BoardRoutePath>
       return BoardRoutePath.create();
     }
 
-    return BoardRoutePath.details(_selectedTaskId);
+    return BoardRoutePath.notFound();
   }
 
   @override

--- a/lib/screens/not_found_screen.dart
+++ b/lib/screens/not_found_screen.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class NotFoundScreen extends StatelessWidget {
+  const NotFoundScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('not-found'),
+      ),
+    );
+  }
+}

--- a/lib/screens/tasks/tasks_create.dart
+++ b/lib/screens/tasks/tasks_create.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class TasksCreateScreen extends StatelessWidget {
+  const TasksCreateScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('タスク作成'),
+      ),
+    );
+  }
+}

--- a/lib/screens/tasks/tasks_detail.dart
+++ b/lib/screens/tasks/tasks_detail.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:board/state/board_route_delegate_state.dart';
+
+class TasksDetailScreen extends ConsumerWidget {
+  const TasksDetailScreen({
+    Key? key,
+    required this.id,
+  }) : super(key: key);
+
+  final String id;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final delegate = ref.watch(boardRouteDelegateProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(delegate.selectedTaskId ?? ''),
+      ),
+    );
+  }
+}

--- a/lib/screens/tasks/tasks_index.dart
+++ b/lib/screens/tasks/tasks_index.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:board/components/tasks/tasks_todo_list.dart';
 import 'package:board/components/tasks/tasks_doing_list.dart';
 import 'package:board/components/tasks/tasks_done_list.dart';
+import 'package:board/state/board_route_delegate_state.dart';
 
 class TaskStatusTabModel {
   const TaskStatusTabModel({required this.title, required this.icon});
@@ -18,21 +19,19 @@ const List<TaskStatusTabModel> taskStatusTabs = [
   TaskStatusTabModel(title: 'DONE', icon: Icons.directions_boat),
 ];
 
-class TasksIndexScreen extends StatelessWidget {
+class TasksIndexScreen extends ConsumerWidget {
   const TasksIndexScreen({Key? key}) : super(key: key);
 
-  void onPressed() {
-    print('onpressed');
-  }
-
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('タスク'),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: onPressed,
+        onPressed: () {
+          ref.read(boardRouteDelegateProvider).setModeToCreate();
+        },
         tooltip: 'Increment',
         child: const Icon(Icons.add),
       ),

--- a/lib/state/board_route_delegate_state.dart
+++ b/lib/state/board_route_delegate_state.dart
@@ -1,0 +1,7 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:board/router/board_router_delegate.dart';
+
+final boardRouteDelegateProvider = ChangeNotifierProvider(
+  (ref) => BoardRouterDelegate(),
+);


### PR DESCRIPTION
## WHY
 - タスク詳細画面にしてタスクの詳細を確認したいのと、作成画面に遷移してタスクを作成したいので、画面遷移を可能にする。

## WHAT
 - 要件の中に navigator2.0を使うことがあるので、それを使ったの実装を行う。
    - 今までのnavigatorの1.0のpushやpopなどの命令的に画面遷移をするのではなく、2.0からルートスタックを宣言的に定義することで画面遷移を可能にする。
    - そのスタックの中身を保持できるように、router_delegateクラスを継承した board_router_delegateを用意した。change_notifierのmixinを入れているので、delegateの中の値を変更して `notifyListeners` を実行して、スタックを再構築することで、画面遷移を行う。
    - routerParserについては、flutterでwebアプリケーションを作るときにURLをパースしたり復元するなどを行うため、モバイルアプリで必要ないが、一旦navigator2.0のことを深く知るためにの記述として残しておく。

## NOTE
  - 参考にした記事:
    - [Learning Flutter’s new navigation and routing system](https://medium.com/flutter/learning-flutters-new-navigation-and-routing-system-7c9068155ade)
    - [【Flutter】最小限のコードで理解する「宣言的な画面遷移」と Navigator 2.0](https://zenn.dev/chooyan/articles/cb09f63a57f0fb)