### PR TITLE
タスク一覧にRefreshIndicatorを追加

### DIFF
--- a/lib/components/tasks/tasks_doing_list.dart
+++ b/lib/components/tasks/tasks_doing_list.dart
@@ -3,6 +3,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'package:board/components/tasks/task_card.dart';
 import 'package:board/providers/tasks_state.dart';
+import 'package:board/models/task_model.dart';
 
 class TasksDoingList extends ConsumerWidget {
   const TasksDoingList({Key? key}) : super(key: key);
@@ -11,18 +12,23 @@ class TasksDoingList extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final tasks = ref.watch(tasksProvider);
 
-    return ListView.builder(
-      itemCount: tasks.length,
-      padding: const EdgeInsets.only(bottom: 60.0),
-      itemBuilder: (BuildContext context, int index) {
-        return TaskCard(
-          id: tasks[index].id,
-          title: tasks[index].title,
-          description: tasks[index].description,
-          dueDateTime: tasks[index].dueDateTime,
-          status: tasks[index].status,
-        );
+    return RefreshIndicator(
+      onRefresh: () {
+        return ref.read(tasksProvider.notifier).findByStatus(taskStatusDoing);
       },
+      child: ListView.builder(
+        itemCount: tasks.length,
+        padding: const EdgeInsets.only(bottom: 60.0),
+        itemBuilder: (BuildContext context, int index) {
+          return TaskCard(
+            id: tasks[index].id,
+            title: tasks[index].title,
+            description: tasks[index].description,
+            dueDateTime: tasks[index].dueDateTime,
+            status: tasks[index].status,
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/components/tasks/tasks_done_list.dart
+++ b/lib/components/tasks/tasks_done_list.dart
@@ -3,6 +3,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'package:board/components/tasks/task_card.dart';
 import 'package:board/providers/tasks_state.dart';
+import 'package:board/models/task_model.dart';
 
 class TasksDoneList extends ConsumerWidget {
   const TasksDoneList({Key? key}) : super(key: key);
@@ -11,18 +12,23 @@ class TasksDoneList extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final tasks = ref.watch(tasksProvider);
 
-    return ListView.builder(
-      itemCount: tasks.length,
-      padding: const EdgeInsets.only(bottom: 60.0),
-      itemBuilder: (BuildContext context, int index) {
-        return TaskCard(
-          id: tasks[index].id,
-          title: tasks[index].title,
-          description: tasks[index].description,
-          dueDateTime: tasks[index].dueDateTime,
-          status: tasks[index].status,
-        );
+    return RefreshIndicator(
+      onRefresh: () {
+        return ref.read(tasksProvider.notifier).findByStatus(taskStatusDone);
       },
+      child: ListView.builder(
+        itemCount: tasks.length,
+        padding: const EdgeInsets.only(bottom: 60.0),
+        itemBuilder: (BuildContext context, int index) {
+          return TaskCard(
+            id: tasks[index].id,
+            title: tasks[index].title,
+            description: tasks[index].description,
+            dueDateTime: tasks[index].dueDateTime,
+            status: tasks[index].status,
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/components/tasks/tasks_todo_list.dart
+++ b/lib/components/tasks/tasks_todo_list.dart
@@ -3,6 +3,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'package:board/components/tasks/task_card.dart';
 import 'package:board/providers/tasks_state.dart';
+import 'package:board/models/task_model.dart';
 
 class TasksTodoList extends ConsumerWidget {
   const TasksTodoList({Key? key}) : super(key: key);
@@ -11,18 +12,23 @@ class TasksTodoList extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final tasks = ref.watch(tasksProvider);
 
-    return ListView.builder(
-      itemCount: tasks.length,
-      padding: const EdgeInsets.only(bottom: 60.0),
-      itemBuilder: (BuildContext context, int index) {
-        return TaskCard(
-          id: tasks[index].id,
-          title: tasks[index].title,
-          description: tasks[index].description,
-          dueDateTime: tasks[index].dueDateTime,
-          status: tasks[index].status,
-        );
+    return RefreshIndicator(
+      onRefresh: () {
+        return ref.read(tasksProvider.notifier).findByStatus(taskStatusTodo);
       },
+      child: ListView.builder(
+        itemCount: tasks.length,
+        padding: const EdgeInsets.only(bottom: 60.0),
+        itemBuilder: (BuildContext context, int index) {
+          return TaskCard(
+            id: tasks[index].id,
+            title: tasks[index].title,
+            description: tasks[index].description,
+            dueDateTime: tasks[index].dueDateTime,
+            status: tasks[index].status,
+          );
+        },
+      ),
     );
   }
 }


### PR DESCRIPTION
## WHY
 - タスク一覧を下にpullしたときにタスクの一覧を更新したいと考えたため、 タスク一覧コンポーネントのlistview.builderを`RefreshIndicator` でラップするようにして、pull to refreshを導入する。