### PR TITLE
タスク作成・編集フォームを実装

### DIFF
--- a/lib/components/tasks/task_card.dart
+++ b/lib/components/tasks/task_card.dart
@@ -58,7 +58,7 @@ class TaskCard extends ConsumerWidget {
                   ),
                 ),
                 Container(
-                  padding: const EdgeInsets.all(6.0),
+                  padding: const EdgeInsets.all(8.0),
                   decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(10),
                     color: statusColor(),

--- a/lib/infra/sqlite/tasks.dart
+++ b/lib/infra/sqlite/tasks.dart
@@ -72,8 +72,6 @@ class TaskSqlite implements TaskRepository {
     final foundIndex = list.indexWhere((e) => e.id == taskId);
     list[foundIndex] = task;
 
-    print(list[foundIndex]);
-
     return Future.value(task);
   }
 }

--- a/lib/infra/sqlite/tasks.dart
+++ b/lib/infra/sqlite/tasks.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:board/repositories/task_repository.dart';
 import 'package:board/models/task_model.dart';
 
@@ -28,11 +26,7 @@ final list = [
 class TaskSqlite implements TaskRepository {
   @override
   Future<TaskModel> find(String taskId) {
-    final _random = Random();
-
-    return Future.value(
-      list[_random.nextInt(list.length)],
-    );
+    return Future.value(list[0]);
   }
 
   @override

--- a/lib/infra/sqlite/tasks.dart
+++ b/lib/infra/sqlite/tasks.dart
@@ -61,4 +61,19 @@ class TaskSqlite implements TaskRepository {
 
     return Future.value(list);
   }
+
+  @override
+  Future<TaskModel> create(TaskModel task) {
+    return Future.value(task);
+  }
+
+  @override
+  Future<TaskModel> update(String taskId, TaskModel task) {
+    final foundIndex = list.indexWhere((e) => e.id == taskId);
+    list[foundIndex] = task;
+
+    print(list[foundIndex]);
+
+    return Future.value(task);
+  }
 }

--- a/lib/models/task_model.dart
+++ b/lib/models/task_model.dart
@@ -18,7 +18,17 @@ class TaskModel {
         dueDateTime = DateTime.now(),
         status = taskStatusTodo;
 
-  final String id = const Uuid().v4();
+  TaskModel.emptyWithoutId(String id)
+      : title = '',
+        description = '',
+        dueDateTime = DateTime.now(),
+        status = taskStatusTodo;
+
+  setId(String id) {
+    this.id = id;
+  }
+
+  String id = const Uuid().v4();
   final String title;
   final String description;
   final DateTime dueDateTime;

--- a/lib/repositories/task_repository.dart
+++ b/lib/repositories/task_repository.dart
@@ -3,4 +3,6 @@ import 'package:board/models/task_model.dart';
 abstract class TaskRepository {
   Future<TaskModel> find(String taskId);
   Future<List<TaskModel>> findByStatus(String status);
+  Future<TaskModel> create(TaskModel task);
+  Future<TaskModel> update(String taskId, TaskModel task);
 }

--- a/lib/router/board_router_delegate.dart
+++ b/lib/router/board_router_delegate.dart
@@ -45,13 +45,13 @@ class BoardRouterDelegate extends RouterDelegate<BoardRoutePath>
           child: BoardHomeScreen(),
         ),
         if (_mode == 'create')
-          const MaterialPage(
-            key: ValueKey('TasksCreateScreen'),
+          MaterialPage(
+            key: const ValueKey('TasksCreateScreen'),
             child: TasksCreateScreen(),
           ),
         if (_mode == 'details')
-          const MaterialPage(
-            key: ValueKey('TasksDetailScreen'),
+          MaterialPage(
+            key: const ValueKey('TasksDetailScreen'),
             child: TasksDetailScreen(),
           ),
         if (_mode == 'not-found')
@@ -107,6 +107,12 @@ class BoardRouterDelegate extends RouterDelegate<BoardRoutePath>
 
   void setModeToCreate() {
     _mode = 'create';
+    notifyListeners();
+  }
+
+  void setModeToList() {
+    _mode = 'list';
+    _selectedTaskId = null;
     notifyListeners();
   }
 }

--- a/lib/screens/tasks/tasks_create.dart
+++ b/lib/screens/tasks/tasks_create.dart
@@ -1,13 +1,179 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:intl/intl.dart';
 
-class TasksCreateScreen extends StatelessWidget {
-  const TasksCreateScreen({Key? key}) : super(key: key);
+import 'package:board/models/task_model.dart';
+import 'package:board/providers/board_route_delegate_state.dart';
+import 'package:board/providers/tasks_state.dart';
+
+class TasksCreateScreen extends HookConsumerWidget {
+  TasksCreateScreen({
+    Key? key,
+  }) : super(key: key);
+
+  final formKey = GlobalKey<FormState>();
+  final formatter = DateFormat('yyyy-MM-dd');
+
+  Future<DateTime?> openDatePikcer(BuildContext context, DateTime date) {
+    return showDatePicker(
+      context: context,
+      initialDate: date,
+      firstDate: DateTime(2020),
+      lastDate: DateTime(2021),
+    );
+  }
+
+  Color? statusColor(String status) {
+    if (status == taskStatusTodo) {
+      return Colors.lime[100];
+    }
+
+    if (status == taskStatusDone) {
+      return Colors.brown[100];
+    }
+
+    return Colors.amber;
+  }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final titleEditingController = useTextEditingController(text: '');
+    final desciptionEditingController = useTextEditingController(text: '');
+    final dateEditingController =
+        useTextEditingController(text: formatter.format(DateTime.now()));
+    final statusDropDownValue = useState(taskStatusTodo);
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('タスク作成'),
+      ),
+      body: Form(
+        key: formKey,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                margin: const EdgeInsets.only(bottom: 16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    TextFormField(
+                      controller: titleEditingController,
+                      maxLength: 12,
+                      decoration:
+                          const InputDecoration(hintText: 'タイトルを入力しましょう'),
+                      keyboardType: TextInputType.text,
+                      // ignore: missing_return
+                      validator: (value) {
+                        if (value!.isEmpty) return 'タイトルは必須項目です';
+                        if (value.length > 12) return 'タイトルは12文字以内で入力してください';
+                      },
+                    ),
+                    TextFormField(
+                      controller: desciptionEditingController,
+                      decoration:
+                          const InputDecoration(hintText: '説明文を入力しましょう'),
+                      keyboardType: TextInputType.text,
+                      maxLength: 50,
+                      // ignore: missing_return
+                      validator: (value) {
+                        if (value!.isEmpty) return '説明文は必須項目です';
+                        if (value.length > 50) return '説明文は50文字以内で入力してください';
+                      },
+                    ),
+                    DropdownButton(
+                      value: statusDropDownValue.value,
+                      icon: const Icon(Icons.arrow_downward),
+                      iconSize: 24,
+                      elevation: 16,
+                      onChanged: (String? newValue) {
+                        statusDropDownValue.value = newValue ?? 'TODO';
+                      },
+                      items: [taskStatusTodo, taskStatusDoing, taskStatusDone]
+                          .map<DropdownMenuItem<String>>(
+                        (String value) {
+                          return DropdownMenuItem<String>(
+                            value: value,
+                            child: Container(
+                              padding: const EdgeInsets.all(8.0),
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(10),
+                                color: statusColor(value),
+                              ),
+                              child: Text(value),
+                            ),
+                          );
+                        },
+                      ).toList(),
+                    ),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: TextFormField(
+                            readOnly: true,
+                            controller: dateEditingController,
+                          ),
+                        ),
+                        Container(
+                          margin: const EdgeInsets.only(left: 8.0),
+                          width: 96,
+                          child: ElevatedButton(
+                            child: const Text('日付設定'),
+                            onPressed: () async {
+                              final result = await openDatePikcer(
+                                context,
+                                DateTime.now(),
+                              );
+
+                              if (result == null) {
+                                return;
+                              }
+
+                              final formatted = formatter.format(result);
+
+                              dateEditingController.text = formatted;
+                            },
+                          ),
+                        ),
+                      ],
+                    )
+                  ],
+                ),
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  ElevatedButton(
+                    child: const Text('保存'),
+                    onPressed: () {
+                      final result = formKey.currentState!.validate();
+                      if (!result) {
+                        return;
+                      }
+
+                      ref.read(tasksProvider.notifier).add(
+                            TaskModel(
+                              title: titleEditingController.text,
+                              description: desciptionEditingController.text,
+                              dueDateTime:
+                                  DateTime.parse(dateEditingController.text),
+                              status: statusDropDownValue.value,
+                            ),
+                          );
+
+                      ref
+                          .read(boardRouteDelegateProvider.notifier)
+                          .setModeToList();
+                    },
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/screens/tasks/tasks_detail.dart
+++ b/lib/screens/tasks/tasks_detail.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:board/models/task_model.dart';
 import 'package:board/providers/board_route_delegate_state.dart';
 import 'package:board/providers/task_detail_state.dart';
+import 'package:board/providers/tasks_state.dart';
 
 class TasksDetailScreen extends HookConsumerWidget {
   TasksDetailScreen({
@@ -180,9 +181,7 @@ class TasksDetailScreen extends HookConsumerWidget {
 
                       task.setId(taskId);
 
-                      ref
-                          .read(taskDetailProvider.notifier)
-                          .editTask(taskId, task);
+                      ref.read(tasksProvider.notifier).edit(taskId, task);
 
                       ref
                           .read(boardRouteDelegateProvider.notifier)

--- a/lib/screens/tasks/tasks_detail.dart
+++ b/lib/screens/tasks/tasks_detail.dart
@@ -1,35 +1,199 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:intl/intl.dart';
 
+import 'package:board/models/task_model.dart';
 import 'package:board/providers/board_route_delegate_state.dart';
 import 'package:board/providers/task_detail_state.dart';
 
 class TasksDetailScreen extends HookConsumerWidget {
-  const TasksDetailScreen({
+  TasksDetailScreen({
     Key? key,
   }) : super(key: key);
 
+  final formKey = GlobalKey<FormState>();
+  final formatter = DateFormat('yyyy-MM-dd');
+
+  Future<DateTime?> openDatePikcer(BuildContext context, DateTime date) {
+    return showDatePicker(
+      context: context,
+      initialDate: date,
+      firstDate: DateTime(2021),
+      lastDate: DateTime(2022),
+    );
+  }
+
+  Color? statusColor(String status) {
+    if (status == taskStatusTodo) {
+      return Colors.lime[100];
+    }
+
+    if (status == taskStatusDone) {
+      return Colors.brown[100];
+    }
+
+    return Colors.amber;
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final delegate = ref.watch(boardRouteDelegateProvider);
+    final delegate = ref.read(boardRouteDelegateProvider);
+
+    final taskId = delegate.selectedTaskId ?? '';
 
     useFuture(
       useMemoized(
-        () => ref
-            .read(taskDetailProvider.notifier)
-            .findById(delegate.selectedTaskId ?? ''),
-        [
-          delegate.selectedTaskId ?? '',
-        ],
+        () => ref.read(taskDetailProvider.notifier).findById(taskId),
+        [taskId],
       ),
     );
 
-    final task = ref.watch(taskDetailProvider);
+    final task = ref.read(taskDetailProvider);
+
+    final titleEditingController = useTextEditingController(text: task.title);
+    final desciptionEditingController =
+        useTextEditingController(text: task.description);
+    final dateEditingController =
+        useTextEditingController(text: formatter.format(task.dueDateTime));
+
+    final statusDropDownValue = useState(task.status);
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(task.title),
+        title: const Text('タスク編集'),
+      ),
+      body: Form(
+        key: formKey,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                margin: const EdgeInsets.only(bottom: 16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    TextFormField(
+                      controller: titleEditingController,
+                      maxLength: 12,
+                      decoration:
+                          const InputDecoration(hintText: 'タイトルを入力しましょう'),
+                      keyboardType: TextInputType.text,
+                      // ignore: missing_return
+                      validator: (value) {
+                        if (value!.isEmpty) return 'タイトルは必須項目です';
+                        if (value.length > 12) return 'タイトルは12文字以内で入力してください';
+                      },
+                    ),
+                    TextFormField(
+                      controller: desciptionEditingController,
+                      decoration:
+                          const InputDecoration(hintText: '説明文を入力しましょう'),
+                      keyboardType: TextInputType.text,
+                      maxLength: 50,
+                      // ignore: missing_return
+                      validator: (value) {
+                        if (value!.isEmpty) return '説明文は必須項目です';
+                        if (value.length > 50) return '説明文は50文字以内で入力してください';
+                      },
+                    ),
+                    DropdownButton(
+                      value: statusDropDownValue.value,
+                      icon: const Icon(Icons.arrow_downward),
+                      iconSize: 24,
+                      elevation: 16,
+                      onChanged: (String? newValue) {
+                        statusDropDownValue.value = newValue ?? 'TODO';
+                      },
+                      items: [taskStatusTodo, taskStatusDoing, taskStatusDone]
+                          .map<DropdownMenuItem<String>>(
+                        (String value) {
+                          return DropdownMenuItem<String>(
+                            value: value,
+                            child: Container(
+                              padding: const EdgeInsets.all(8.0),
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(10),
+                                color: statusColor(value),
+                              ),
+                              child: Text(value),
+                            ),
+                          );
+                        },
+                      ).toList(),
+                    ),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: TextFormField(
+                            readOnly: true,
+                            controller: dateEditingController,
+                          ),
+                        ),
+                        Container(
+                          margin: const EdgeInsets.only(left: 8.0),
+                          width: 96,
+                          child: ElevatedButton(
+                            child: const Text('日付設定'),
+                            onPressed: () async {
+                              final result = await openDatePikcer(
+                                context,
+                                DateTime.now(),
+                              );
+
+                              if (result == null) {
+                                return;
+                              }
+
+                              final formatted = formatter.format(result);
+
+                              dateEditingController.text = formatted;
+                            },
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  ElevatedButton(
+                    child: const Text('保存'),
+                    onPressed: () {
+                      final result = formKey.currentState!.validate();
+                      if (!result) {
+                        return;
+                      }
+
+                      final task = TaskModel(
+                        title: titleEditingController.text,
+                        description: desciptionEditingController.text,
+                        dueDateTime: DateTime.parse(
+                          dateEditingController.text,
+                        ),
+                        status: statusDropDownValue.value,
+                      );
+
+                      task.setId(taskId);
+
+                      ref
+                          .read(taskDetailProvider.notifier)
+                          .editTask(taskId, task);
+
+                      ref
+                          .read(boardRouteDelegateProvider.notifier)
+                          .setModeToList();
+                    },
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/viewmodels/task_detail_change_notifier.dart
+++ b/lib/viewmodels/task_detail_change_notifier.dart
@@ -14,4 +14,14 @@ class TaskDetailChangeNotifier extends StateNotifier<TaskModel> {
       state = value;
     }).catchError((dynamic error) {});
   }
+
+  Future<TaskModel> createTask(TaskModel taskModel) async {
+    return repository.create(taskModel);
+  }
+
+  Future<void> editTask(String taskId, TaskModel taskModel) async {
+    return repository.update(taskId, taskModel).then((value) {
+      state = value;
+    }).catchError((dynamic error) {});
+  }
 }

--- a/lib/viewmodels/task_detail_change_notifier.dart
+++ b/lib/viewmodels/task_detail_change_notifier.dart
@@ -18,10 +18,4 @@ class TaskDetailChangeNotifier extends StateNotifier<TaskModel> {
   Future<TaskModel> createTask(TaskModel taskModel) async {
     return repository.create(taskModel);
   }
-
-  Future<void> editTask(String taskId, TaskModel taskModel) async {
-    return repository.update(taskId, taskModel).then((value) {
-      state = value;
-    }).catchError((dynamic error) {});
-  }
 }

--- a/lib/viewmodels/task_list_change_notifier.dart
+++ b/lib/viewmodels/task_list_change_notifier.dart
@@ -19,4 +19,12 @@ class TaskListChangeNotifier extends StateNotifier<List<TaskModel>> {
       state = [...state, value];
     }).catchError((dynamic error) {});
   }
+
+  Future<void> edit(String taskId, TaskModel taskModel) async {
+    return repository.update(taskId, taskModel).then((value) {
+      return repository.findByStatus(taskStatusDone);
+    }).then((newList) {
+      state = [...newList];
+    }).catchError((dynamic error) {});
+  }
 }

--- a/lib/viewmodels/task_list_change_notifier.dart
+++ b/lib/viewmodels/task_list_change_notifier.dart
@@ -13,4 +13,10 @@ class TaskListChangeNotifier extends StateNotifier<List<TaskModel>> {
       state = value;
     }).catchError((dynamic error) {});
   }
+
+  Future<void> add(TaskModel task) async {
+    return repository.create(task).then((value) {
+      state = [...state, value];
+    }).catchError((dynamic error) {});
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,6 +109,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.0"
   lints:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,9 @@ version: 1.0.0+1
 environment:
   sdk: ">=2.14.0 <3.0.0"
 
+flutter_localizations:
+  sdk: flutter
+
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
 # consider running `flutter pub upgrade --major-versions`. Alternatively,
@@ -37,6 +40,7 @@ dependencies:
   hooks_riverpod: 1.0.0
   app_settings: 4.1.1
   uuid: 3.0.5
+  intl: 0.17.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## WHY
 - 要件的にはタスクの一覧をTODO / DOING / DONEのリストで分けて表示するのがあるが、flutterの勉強のために追加でそのタスクを自分で作成、編集できるようにした。
 
## WHAT
 - repository層とその実態のinfra層にデータを作成する処理の入り口と更新する処理の入り口を設ける。
 - 作成と更新画面に簡易なフォーム処理を追加する。
   - タイトルと説明文にはバリエーションをつけて、保存時にバリエーションを発火する。
 - 作成と更新が終わったら、タスクのリストを保持している StateChangeNotifierのstateを上書きすることで、viewのほうにデータを表示させる。 
 - 日付のフォーマットをかけるため、intlパッケージをインストール 

## NOTE
 - このPRで対応しないこと。
   - sqliteにデータを入れたり、更新するのはこの後のPRで行う。
   - 作成と更新画面で同じ処理が書かれてしまっているため、要件をまず最初に満たしてから共通のwidgetを設けるようにする。