### PR TITLE
infra層をmockデータからsqliteに置き換える

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,20 +2,35 @@ PODS:
   - "app_settings (3.0.0+1)":
     - Flutter
   - Flutter (1.0.0)
+  - FMDB (2.7.5):
+    - FMDB/standard (= 2.7.5)
+  - FMDB/standard (2.7.5)
+  - sqflite (0.0.2):
+    - Flutter
+    - FMDB (>= 2.7.5)
 
 DEPENDENCIES:
   - app_settings (from `.symlinks/plugins/app_settings/ios`)
   - Flutter (from `Flutter`)
+  - sqflite (from `.symlinks/plugins/sqflite/ios`)
+
+SPEC REPOS:
+  trunk:
+    - FMDB
 
 EXTERNAL SOURCES:
   app_settings:
     :path: ".symlinks/plugins/app_settings/ios"
   Flutter:
     :path: Flutter
+  sqflite:
+    :path: ".symlinks/plugins/sqflite/ios"
 
 SPEC CHECKSUMS:
   app_settings: d103828c9f5d515c4df9ee754dabd443f7cedcf3
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
+  sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
 
 PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
 

--- a/lib/components/tasks/tasks_doing_list.dart
+++ b/lib/components/tasks/tasks_doing_list.dart
@@ -16,19 +16,26 @@ class TasksDoingList extends ConsumerWidget {
       onRefresh: () {
         return ref.read(tasksProvider.notifier).findByStatus(taskStatusDoing);
       },
-      child: ListView.builder(
-        itemCount: tasks.length,
-        padding: const EdgeInsets.only(bottom: 60.0),
-        itemBuilder: (BuildContext context, int index) {
-          return TaskCard(
-            id: tasks[index].id,
-            title: tasks[index].title,
-            description: tasks[index].description,
-            dueDateTime: tasks[index].dueDateTime,
-            status: tasks[index].status,
-          );
-        },
-      ),
+      child: tasks.isEmpty
+          ? const Center(
+              child: Text(
+                '$taskStatusDoingのタスクはありません',
+                style: TextStyle(fontSize: 16),
+              ),
+            )
+          : ListView.builder(
+              itemCount: tasks.length,
+              padding: const EdgeInsets.only(bottom: 60.0),
+              itemBuilder: (BuildContext context, int index) {
+                return TaskCard(
+                  id: tasks[index].id,
+                  title: tasks[index].title,
+                  description: tasks[index].description,
+                  dueDateTime: tasks[index].dueDateTime,
+                  status: tasks[index].status,
+                );
+              },
+            ),
     );
   }
 }

--- a/lib/components/tasks/tasks_done_list.dart
+++ b/lib/components/tasks/tasks_done_list.dart
@@ -16,19 +16,25 @@ class TasksDoneList extends ConsumerWidget {
       onRefresh: () {
         return ref.read(tasksProvider.notifier).findByStatus(taskStatusDone);
       },
-      child: ListView.builder(
-        itemCount: tasks.length,
-        padding: const EdgeInsets.only(bottom: 60.0),
-        itemBuilder: (BuildContext context, int index) {
-          return TaskCard(
-            id: tasks[index].id,
-            title: tasks[index].title,
-            description: tasks[index].description,
-            dueDateTime: tasks[index].dueDateTime,
-            status: tasks[index].status,
-          );
-        },
-      ),
+      child: tasks.isEmpty
+          ? const Center(
+              child: Text(
+              '$taskStatusDoneのタスクはありません',
+              style: TextStyle(fontSize: 16),
+            ))
+          : ListView.builder(
+              itemCount: tasks.length,
+              padding: const EdgeInsets.only(bottom: 60.0),
+              itemBuilder: (BuildContext context, int index) {
+                return TaskCard(
+                  id: tasks[index].id,
+                  title: tasks[index].title,
+                  description: tasks[index].description,
+                  dueDateTime: tasks[index].dueDateTime,
+                  status: tasks[index].status,
+                );
+              },
+            ),
     );
   }
 }

--- a/lib/components/tasks/tasks_todo_list.dart
+++ b/lib/components/tasks/tasks_todo_list.dart
@@ -16,19 +16,25 @@ class TasksTodoList extends ConsumerWidget {
       onRefresh: () {
         return ref.read(tasksProvider.notifier).findByStatus(taskStatusTodo);
       },
-      child: ListView.builder(
-        itemCount: tasks.length,
-        padding: const EdgeInsets.only(bottom: 60.0),
-        itemBuilder: (BuildContext context, int index) {
-          return TaskCard(
-            id: tasks[index].id,
-            title: tasks[index].title,
-            description: tasks[index].description,
-            dueDateTime: tasks[index].dueDateTime,
-            status: tasks[index].status,
-          );
-        },
-      ),
+      child: tasks.isEmpty
+          ? const Center(
+              child: Text(
+              '$taskStatusTodoのタスクはありません',
+              style: TextStyle(fontSize: 16),
+            ))
+          : ListView.builder(
+              itemCount: tasks.length,
+              padding: const EdgeInsets.only(bottom: 60.0),
+              itemBuilder: (BuildContext context, int index) {
+                return TaskCard(
+                  id: tasks[index].id,
+                  title: tasks[index].title,
+                  description: tasks[index].description,
+                  dueDateTime: tasks[index].dueDateTime,
+                  status: tasks[index].status,
+                );
+              },
+            ),
     );
   }
 }

--- a/lib/infra/sqlite/init.dart
+++ b/lib/infra/sqlite/init.dart
@@ -1,0 +1,30 @@
+import 'package:sqflite/sqflite.dart';
+import 'package:path/path.dart';
+
+class SqliteClient {
+  static Database? _database;
+
+  Future<Database> get database async {
+    if (_database != null) {
+      return _database!;
+    }
+
+    _database = await initDatabase();
+    return _database!;
+  }
+
+  Future<Database> initDatabase() async {
+    final databasesPath = await getDatabasesPath();
+    final path = join(databasesPath, 'board_database_v2.db');
+
+    return openDatabase(
+      path,
+      version: 1,
+      onCreate: (db, version) async {
+        await db.execute(
+          "CREATE TABLE tasks(id VARCHAR(255) PRIMARY KEY, title VARCHAR(255), description TEXT, dueDateTime VARCHAR(255), status VARCHAR(255))",
+        );
+      },
+    );
+  }
+}

--- a/lib/infra/sqlite/tasks.dart
+++ b/lib/infra/sqlite/tasks.dart
@@ -1,77 +1,46 @@
 import 'package:board/repositories/task_repository.dart';
 import 'package:board/models/task_model.dart';
-
-final list = [
-  TaskModel(
-    title: "taskStatusTodo",
-    description:
-        "descriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescription",
-    dueDateTime: DateTime.now(),
-    status: taskStatusTodo,
-  ),
-  TaskModel(
-    title: "taskStatusTodo2",
-    description: "description2",
-    dueDateTime: DateTime.now(),
-    status: taskStatusTodo,
-  ),
-  TaskModel(
-    title: "taskStatusTodo3",
-    description: "description3",
-    dueDateTime: DateTime.now(),
-    status: taskStatusTodo,
-  )
-];
+import 'package:board/infra/sqlite/init.dart';
 
 class TaskSqlite implements TaskRepository {
+  TaskSqlite({required this.client});
+
+  SqliteClient client;
+  final String _tableName = 'tasks';
+
   @override
-  Future<TaskModel> find(String taskId) {
-    return Future.value(list[0]);
+  Future<TaskModel> find(String taskId) async {
+    final database = await client.database;
+    final res = await database
+        .rawQuery("select * from $_tableName where id = '$taskId'");
+    final tasks = res.map((c) => TaskModel.fromMap(c)).toList();
+    return tasks.isEmpty ? TaskModel.empty() : tasks[0];
   }
 
   @override
-  Future<List<TaskModel>> findByStatus(String status) {
-    if (status == taskStatusDoing) {
-      return Future.value(
-        [
-          TaskModel(
-            title: "taskStatusDoing",
-            description:
-                "descriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescription",
-            dueDateTime: DateTime.now(),
-            status: taskStatusDoing,
-          ),
-        ],
-      );
-    }
-
-    if (status == taskStatusDone) {
-      return Future.value(
-        [
-          TaskModel(
-            title: "taskStatusDone",
-            description:
-                "descriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescription",
-            dueDateTime: DateTime.now(),
-            status: taskStatusDone,
-          ),
-        ],
-      );
-    }
-
-    return Future.value(list);
+  Future<List<TaskModel>> findByStatus(String status) async {
+    final database = await client.database;
+    final res = await database
+        .rawQuery("select * from $_tableName where status = '$status'");
+    return res.map((c) => TaskModel.fromMap(c)).toList();
   }
 
   @override
-  Future<TaskModel> create(TaskModel task) {
-    return Future.value(task);
+  Future<TaskModel> create(TaskModel task) async {
+    final database = await client.database;
+    await database.insert(_tableName, task.toMap());
+    return task;
   }
 
   @override
-  Future<TaskModel> update(String taskId, TaskModel task) {
-    final foundIndex = list.indexWhere((e) => e.id == taskId);
-    list[foundIndex] = task;
-
-    return Future.value(task);
+  Future<TaskModel> update(String taskId, TaskModel task) async {
+    final database = await client.database;
+    await database.update(
+      _tableName,
+      task.toMap(),
+      where: "id = ?",
+      whereArgs: [taskId],
+    );
+    return task;
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,8 +3,11 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'package:board/providers/board_route_delegate_provider.dart';
 import 'package:board/router/board_route_information_parser.dart';
+import 'package:board/infra/sqlite/init.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await SqliteClient().initDatabase();
   runApp(const ProviderScope(child: MyApp()));
 }
 

--- a/lib/models/task_model.dart
+++ b/lib/models/task_model.dart
@@ -6,6 +6,7 @@ const String taskStatusDone = 'DONE';
 
 class TaskModel {
   TaskModel({
+    required this.id,
     required this.title,
     required this.description,
     required this.dueDateTime,
@@ -19,7 +20,8 @@ class TaskModel {
   final String status;
 
   TaskModel.empty()
-      : title = '',
+      : id = '',
+        title = '',
         description = '',
         dueDateTime = DateTime.now(),
         status = taskStatusTodo;

--- a/lib/models/task_model.dart
+++ b/lib/models/task_model.dart
@@ -36,4 +36,19 @@ class TaskModel {
     this.id = id;
   }
 
+  factory TaskModel.fromMap(Map<String, dynamic> json) => TaskModel(
+        id: json["id"],
+        title: json["title"],
+        description: json["description"],
+        dueDateTime: DateTime.parse(json["dueDateTime"]).toLocal(),
+        status: json["status"],
+      );
+
+  Map<String, dynamic> toMap() => {
+        "id": id,
+        "title": title,
+        "description": description,
+        "dueDateTime": dueDateTime.toUtc().toIso8601String(),
+        "status": status
+      };
 }

--- a/lib/models/task_model.dart
+++ b/lib/models/task_model.dart
@@ -12,6 +12,12 @@ class TaskModel {
     required this.status,
   });
 
+  String id = const Uuid().v4();
+  final String title;
+  final String description;
+  final DateTime dueDateTime;
+  final String status;
+
   TaskModel.empty()
       : title = '',
         description = '',
@@ -28,9 +34,4 @@ class TaskModel {
     this.id = id;
   }
 
-  String id = const Uuid().v4();
-  final String title;
-  final String description;
-  final DateTime dueDateTime;
-  final String status;
 }

--- a/lib/providers/task_detail_provider.dart
+++ b/lib/providers/task_detail_provider.dart
@@ -3,8 +3,11 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:board/viewmodels/task_detail_change_notifier.dart';
 import 'package:board/models/task_model.dart';
 import 'package:board/infra/sqlite/tasks.dart';
+import 'package:board/infra/sqlite/init.dart';
 
 final taskDetailProvider =
     StateNotifierProvider<TaskDetailChangeNotifier, TaskModel>(
-  (ref) => TaskDetailChangeNotifier(repository: TaskSqlite()),
+  (ref) => TaskDetailChangeNotifier(
+    repository: TaskSqlite(client: SqliteClient()),
+  ),
 );

--- a/lib/providers/tasks_provider.dart
+++ b/lib/providers/tasks_provider.dart
@@ -3,8 +3,10 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:board/viewmodels/task_list_change_notifier.dart';
 import 'package:board/models/task_model.dart';
 import 'package:board/infra/sqlite/tasks.dart';
+import 'package:board/infra/sqlite/init.dart';
 
 final tasksProvider =
     StateNotifierProvider<TaskListChangeNotifier, List<TaskModel>>(
-  (ref) => TaskListChangeNotifier(repository: TaskSqlite()),
+  (ref) =>
+      TaskListChangeNotifier(repository: TaskSqlite(client: SqliteClient())),
 );

--- a/lib/screens/tasks/tasks_create.dart
+++ b/lib/screens/tasks/tasks_create.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:intl/intl.dart';
+import 'package:uuid/uuid.dart';
 
 import 'package:board/models/task_model.dart';
 import 'package:board/providers/board_route_delegate_provider.dart';
@@ -156,6 +157,7 @@ class TasksCreateScreen extends HookConsumerWidget {
 
                       ref.read(tasksProvider.notifier).add(
                             TaskModel(
+                              id: const Uuid().v4(),
                               title: titleEditingController.text,
                               description: desciptionEditingController.text,
                               dueDateTime:

--- a/lib/screens/tasks/tasks_create.dart
+++ b/lib/screens/tasks/tasks_create.dart
@@ -67,7 +67,6 @@ class TasksCreateScreen extends HookConsumerWidget {
                       decoration:
                           const InputDecoration(hintText: 'タイトルを入力しましょう'),
                       keyboardType: TextInputType.text,
-                      // ignore: missing_return
                       validator: (value) {
                         if (value!.isEmpty) return 'タイトルは必須項目です';
                         if (value.length > 12) return 'タイトルは12文字以内で入力してください';
@@ -79,7 +78,6 @@ class TasksCreateScreen extends HookConsumerWidget {
                           const InputDecoration(hintText: '説明文を入力しましょう'),
                       keyboardType: TextInputType.text,
                       maxLength: 50,
-                      // ignore: missing_return
                       validator: (value) {
                         if (value!.isEmpty) return '説明文は必須項目です';
                         if (value.length > 50) return '説明文は50文字以内で入力してください';

--- a/lib/screens/tasks/tasks_detail.dart
+++ b/lib/screens/tasks/tasks_detail.dart
@@ -193,7 +193,9 @@ class TasksDetailScreen extends HookConsumerWidget {
 
                           task.setId(taskId);
 
-                          ref.read(tasksProvider.notifier).edit(taskId, task);
+                          ref
+                              .read(tasksProvider.notifier)
+                              .edit(taskId, task.status, updatedTask);
 
                           ref
                               .read(boardRouteDelegateProvider.notifier)

--- a/lib/screens/tasks/tasks_detail.dart
+++ b/lib/screens/tasks/tasks_detail.dart
@@ -181,8 +181,8 @@ class TasksDetailScreen extends HookConsumerWidget {
                             return;
                           }
 
-                          final task = TaskModel(
-                            id: const Uuid().v4(),
+                          final updatedTask = TaskModel(
+                            id: task.id,
                             title: titleEditingController.text,
                             description: desciptionEditingController.text,
                             dueDateTime: DateTime.parse(

--- a/lib/screens/tasks/tasks_detail.dart
+++ b/lib/screens/tasks/tasks_detail.dart
@@ -89,11 +89,12 @@ class TasksDetailScreen extends HookConsumerWidget {
                           decoration:
                               const InputDecoration(hintText: 'タイトルを入力しましょう'),
                           keyboardType: TextInputType.text,
-                          // ignore: missing_return
                           validator: (value) {
-                            if (value!.isEmpty) return 'タイトルは必須項目です';
-                            if (value.length > 12)
+                            if (value!.isEmpty) {
+                              return 'タイトルは必須項目です';
+                            } else if (value.length > 12) {
                               return 'タイトルは12文字以内で入力してください';
+                            }
                           },
                         ),
                         TextFormField(
@@ -102,7 +103,6 @@ class TasksDetailScreen extends HookConsumerWidget {
                               const InputDecoration(hintText: '説明文を入力しましょう'),
                           keyboardType: TextInputType.text,
                           maxLength: 50,
-                          // ignore: missing_return
                           validator: (value) {
                             if (value!.isEmpty) return '説明文は必須項目です';
                             if (value.length > 50) return '説明文は50文字以内で入力してください';

--- a/lib/screens/tasks/tasks_detail.dart
+++ b/lib/screens/tasks/tasks_detail.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:intl/intl.dart';
+import 'package:uuid/uuid.dart';
 
 import 'package:board/models/task_model.dart';
 import 'package:board/providers/board_route_delegate_provider.dart';
@@ -43,156 +44,169 @@ class TasksDetailScreen extends HookConsumerWidget {
 
     final taskId = delegate.selectedTaskId ?? '';
 
-    useFuture(
-      useMemoized(
-        () => ref.read(taskDetailProvider.notifier).findById(taskId),
-        [taskId],
-      ),
-    );
-
-    final task = ref.read(taskDetailProvider);
-
-    final titleEditingController = useTextEditingController(text: task.title);
-    final desciptionEditingController =
-        useTextEditingController(text: task.description);
-    final dateEditingController =
-        useTextEditingController(text: formatter.format(task.dueDateTime));
-
-    final statusDropDownValue = useState(task.status);
-
     return Scaffold(
       appBar: AppBar(
         title: const Text('タスク編集'),
       ),
-      body: Form(
-        key: formKey,
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                margin: const EdgeInsets.only(bottom: 16.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    TextFormField(
-                      controller: titleEditingController,
-                      maxLength: 12,
-                      decoration:
-                          const InputDecoration(hintText: 'タイトルを入力しましょう'),
-                      keyboardType: TextInputType.text,
-                      // ignore: missing_return
-                      validator: (value) {
-                        if (value!.isEmpty) return 'タイトルは必須項目です';
-                        if (value.length > 12) return 'タイトルは12文字以内で入力してください';
-                      },
-                    ),
-                    TextFormField(
-                      controller: desciptionEditingController,
-                      decoration:
-                          const InputDecoration(hintText: '説明文を入力しましょう'),
-                      keyboardType: TextInputType.text,
-                      maxLength: 50,
-                      // ignore: missing_return
-                      validator: (value) {
-                        if (value!.isEmpty) return '説明文は必須項目です';
-                        if (value.length > 50) return '説明文は50文字以内で入力してください';
-                      },
-                    ),
-                    DropdownButton(
-                      value: statusDropDownValue.value,
-                      icon: const Icon(Icons.arrow_downward),
-                      iconSize: 24,
-                      elevation: 16,
-                      onChanged: (String? newValue) {
-                        statusDropDownValue.value = newValue ?? 'TODO';
-                      },
-                      items: [taskStatusTodo, taskStatusDoing, taskStatusDone]
-                          .map<DropdownMenuItem<String>>(
-                        (String value) {
-                          return DropdownMenuItem<String>(
-                            value: value,
-                            child: Container(
-                              padding: const EdgeInsets.all(8.0),
-                              decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(10),
-                                color: statusColor(value),
-                              ),
-                              child: Text(value),
-                            ),
-                          );
-                        },
-                      ).toList(),
-                    ),
-                    Row(
+      body: HookBuilder(
+        builder: (context) {
+          useFuture(
+            useMemoized(
+              () => ref.read(taskDetailProvider.notifier).findById(taskId),
+              [taskId],
+            ),
+          );
+
+          final task = ref.watch(taskDetailProvider);
+          if (task.id == '') {
+            return const CircularProgressIndicator();
+          }
+
+          final titleEditingController =
+              useTextEditingController(text: task.title);
+          final desciptionEditingController =
+              useTextEditingController(text: task.description);
+          final dateEditingController = useTextEditingController(
+              text: formatter.format(task.dueDateTime));
+
+          final statusDropDownValue = useState(task.status);
+
+          return Form(
+            key: formKey,
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    margin: const EdgeInsets.only(bottom: 16.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Expanded(
-                          child: TextFormField(
-                            readOnly: true,
-                            controller: dateEditingController,
-                          ),
+                        TextFormField(
+                          controller: titleEditingController,
+                          maxLength: 12,
+                          decoration:
+                              const InputDecoration(hintText: 'タイトルを入力しましょう'),
+                          keyboardType: TextInputType.text,
+                          // ignore: missing_return
+                          validator: (value) {
+                            if (value!.isEmpty) return 'タイトルは必須項目です';
+                            if (value.length > 12)
+                              return 'タイトルは12文字以内で入力してください';
+                          },
                         ),
-                        Container(
-                          margin: const EdgeInsets.only(left: 8.0),
-                          width: 96,
-                          child: ElevatedButton(
-                            child: const Text('日付設定'),
-                            onPressed: () async {
-                              final result = await openDatePikcer(
-                                context,
-                                DateTime.now(),
+                        TextFormField(
+                          controller: desciptionEditingController,
+                          decoration:
+                              const InputDecoration(hintText: '説明文を入力しましょう'),
+                          keyboardType: TextInputType.text,
+                          maxLength: 50,
+                          // ignore: missing_return
+                          validator: (value) {
+                            if (value!.isEmpty) return '説明文は必須項目です';
+                            if (value.length > 50) return '説明文は50文字以内で入力してください';
+                          },
+                        ),
+                        DropdownButton(
+                          value: statusDropDownValue.value,
+                          icon: const Icon(Icons.arrow_downward),
+                          iconSize: 24,
+                          elevation: 16,
+                          onChanged: (String? newValue) {
+                            statusDropDownValue.value = newValue ?? 'TODO';
+                          },
+                          items: [
+                            taskStatusTodo,
+                            taskStatusDoing,
+                            taskStatusDone
+                          ].map<DropdownMenuItem<String>>(
+                            (String value) {
+                              return DropdownMenuItem<String>(
+                                value: value,
+                                child: Container(
+                                  padding: const EdgeInsets.all(8.0),
+                                  decoration: BoxDecoration(
+                                    borderRadius: BorderRadius.circular(10),
+                                    color: statusColor(value),
+                                  ),
+                                  child: Text(value),
+                                ),
                               );
-
-                              if (result == null) {
-                                return;
-                              }
-
-                              final formatted = formatter.format(result);
-
-                              dateEditingController.text = formatted;
                             },
-                          ),
+                          ).toList(),
+                        ),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: TextFormField(
+                                readOnly: true,
+                                controller: dateEditingController,
+                              ),
+                            ),
+                            Container(
+                              margin: const EdgeInsets.only(left: 8.0),
+                              width: 96,
+                              child: ElevatedButton(
+                                child: const Text('日付設定'),
+                                onPressed: () async {
+                                  final result = await openDatePikcer(
+                                    context,
+                                    DateTime.now(),
+                                  );
+
+                                  if (result == null) {
+                                    return;
+                                  }
+
+                                  final formatted = formatter.format(result);
+
+                                  dateEditingController.text = formatted;
+                                },
+                              ),
+                            ),
+                          ],
                         ),
                       ],
                     ),
-                  ],
-                ),
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  ElevatedButton(
-                    child: const Text('保存'),
-                    onPressed: () {
-                      final result = formKey.currentState!.validate();
-                      if (!result) {
-                        return;
-                      }
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      ElevatedButton(
+                        child: const Text('保存'),
+                        onPressed: () {
+                          final result = formKey.currentState!.validate();
+                          if (!result) {
+                            return;
+                          }
 
-                      final task = TaskModel(
-                        title: titleEditingController.text,
-                        description: desciptionEditingController.text,
-                        dueDateTime: DateTime.parse(
-                          dateEditingController.text,
-                        ),
-                        status: statusDropDownValue.value,
-                      );
+                          final task = TaskModel(
+                            id: const Uuid().v4(),
+                            title: titleEditingController.text,
+                            description: desciptionEditingController.text,
+                            dueDateTime: DateTime.parse(
+                              dateEditingController.text,
+                            ),
+                            status: statusDropDownValue.value,
+                          );
 
-                      task.setId(taskId);
+                          task.setId(taskId);
 
-                      ref.read(tasksProvider.notifier).edit(taskId, task);
+                          ref.read(tasksProvider.notifier).edit(taskId, task);
 
-                      ref
-                          .read(boardRouteDelegateProvider.notifier)
-                          .setModeToList();
-                    },
+                          ref
+                              .read(boardRouteDelegateProvider.notifier)
+                              .setModeToList();
+                        },
+                      ),
+                    ],
                   ),
                 ],
               ),
-            ],
-          ),
-        ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/viewmodels/task_list_change_notifier.dart
+++ b/lib/viewmodels/task_list_change_notifier.dart
@@ -20,9 +20,13 @@ class TaskListChangeNotifier extends StateNotifier<List<TaskModel>> {
     }).catchError((dynamic error) {});
   }
 
-  Future<void> edit(String taskId, TaskModel taskModel) async {
+  Future<void> edit(
+    String taskId,
+    String previousTaskStatus,
+    TaskModel taskModel,
+  ) async {
     return repository.update(taskId, taskModel).then((value) {
-      return repository.findByStatus(taskStatusDone);
+      return repository.findByStatus(previousTaskStatus);
     }).then((newList) {
       state = [...newList];
     }).catchError((dynamic error) {});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -163,6 +163,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
+  sqflite:
+    dependency: "direct main"
+    description:
+      name: sqflite
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0+4"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1+1"
   stack_trace:
     dependency: transitive
     description:
@@ -191,6 +205,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   app_settings: 4.1.1
   uuid: 3.0.5
   intl: 0.17.0
+  sqflite: 2.0.0+4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## WHY
 - 要件の中にsqliteからデータを取得するようにするとあるので、sqliteを導入。

## WHAT
 - sqfliteパッケージをインストールした。
 - TODO / DOING / DONEのタスクリストのwidgetそれぞれにタスクがないときのempty表示を用意した。
 - infra/sqlite/tasks.dart の中にある mockデータを削除し、sqliteのデータ取得やデータ作成更新の処理に置き換えた。
 - task詳細スクリーンに遷移するときに、空のタスクモデルがある状態で最初ビルドが走る。そして、タスクを取得し直したときにformコンポーネントに再ビルドをかけてほしいため、空のモデルのときはloading widgetを表示する条件を書くために、HookBuilderを使う。(本当は一回のビルドでなんとかするように修正する。）