### PR TITLE
フォームwidgetの共通化

### DIFF
--- a/lib/components/tasks/task_form.dart
+++ b/lib/components/tasks/task_form.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:intl/intl.dart';
+
+import 'package:board/models/task_model.dart';
+
+class TaskForm extends HookConsumerWidget {
+  TaskForm({
+    Key? key,
+    required this.taskId,
+    required this.title,
+    required this.description,
+    required this.dueDateTime,
+    required this.status,
+    required this.onSaveTapped,
+  }) : super(key: key);
+
+  final formKey = GlobalKey<FormState>();
+  final formatter = DateFormat('yyyy-MM-dd');
+
+  final String taskId;
+  final String title;
+  final String description;
+  final DateTime dueDateTime;
+  final String status;
+  final Function(TaskModel) onSaveTapped;
+
+  Future<DateTime?> openDatePikcer(BuildContext context, DateTime date) {
+    return showDatePicker(
+      context: context,
+      initialDate: date,
+      firstDate: DateTime(2021),
+      lastDate: DateTime(2022),
+    );
+  }
+
+  Color? statusColor(String status) {
+    if (status == taskStatusTodo) {
+      return Colors.lime[100];
+    }
+
+    if (status == taskStatusDone) {
+      return Colors.brown[100];
+    }
+
+    return Colors.amber;
+  }
+
+  @override
+  build(BuildContext context, WidgetRef ref) {
+    final titleEditingController = useTextEditingController(text: title);
+    final desciptionEditingController =
+        useTextEditingController(text: description);
+    final dateEditingController =
+        useTextEditingController(text: formatter.format(dueDateTime));
+
+    final statusDropDownValue = useState(status);
+
+    return Form(
+      key: formKey,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              margin: const EdgeInsets.only(bottom: 16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  TextFormField(
+                    controller: titleEditingController,
+                    maxLength: 12,
+                    decoration: const InputDecoration(hintText: 'タイトルを入力しましょう'),
+                    keyboardType: TextInputType.text,
+                    validator: (value) {
+                      if (value!.isEmpty) return 'タイトルは必須項目です';
+                      if (value.length > 12) return 'タイトルは12文字以内で入力してください';
+                    },
+                  ),
+                  TextFormField(
+                    controller: desciptionEditingController,
+                    decoration: const InputDecoration(hintText: '説明文を入力しましょう'),
+                    keyboardType: TextInputType.text,
+                    maxLength: 50,
+                    validator: (value) {
+                      if (value!.isEmpty) return '説明文は必須項目です';
+                      if (value.length > 50) return '説明文は50文字以内で入力してください';
+                    },
+                  ),
+                  DropdownButton(
+                    value: statusDropDownValue.value,
+                    icon: const Icon(Icons.arrow_downward),
+                    iconSize: 24,
+                    elevation: 16,
+                    onChanged: (String? newValue) {
+                      statusDropDownValue.value = newValue ?? 'TODO';
+                    },
+                    items: [taskStatusTodo, taskStatusDoing, taskStatusDone]
+                        .map<DropdownMenuItem<String>>(
+                      (String value) {
+                        return DropdownMenuItem<String>(
+                          value: value,
+                          child: Container(
+                            padding: const EdgeInsets.all(8.0),
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(10),
+                              color: statusColor(value),
+                            ),
+                            child: Text(value),
+                          ),
+                        );
+                      },
+                    ).toList(),
+                  ),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: TextFormField(
+                          readOnly: true,
+                          controller: dateEditingController,
+                        ),
+                      ),
+                      Container(
+                        margin: const EdgeInsets.only(left: 8.0),
+                        width: 96,
+                        child: ElevatedButton(
+                          child: const Text('日付設定'),
+                          onPressed: () async {
+                            final result = await openDatePikcer(
+                              context,
+                              DateTime.now(),
+                            );
+
+                            if (result == null) {
+                              return;
+                            }
+
+                            final formatted = formatter.format(result);
+
+                            dateEditingController.text = formatted;
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                ElevatedButton(
+                  child: const Text('保存'),
+                  onPressed: () {
+                    final result = formKey.currentState!.validate();
+                    if (!result) {
+                      return;
+                    }
+
+                    final newTask = TaskModel(
+                      id: taskId,
+                      title: titleEditingController.text,
+                      description: desciptionEditingController.text,
+                      dueDateTime: DateTime.parse(
+                        dateEditingController.text,
+                      ),
+                      status: statusDropDownValue.value,
+                    );
+
+                    onSaveTapped(newTask);
+                  },
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/models/task_model.dart
+++ b/lib/models/task_model.dart
@@ -32,10 +32,6 @@ class TaskModel {
         dueDateTime = DateTime.now(),
         status = taskStatusTodo;
 
-  setId(String id) {
-    this.id = id;
-  }
-
   factory TaskModel.fromMap(Map<String, dynamic> json) => TaskModel(
         id: json["id"],
         title: json["title"],

--- a/lib/screens/tasks/tasks_create.dart
+++ b/lib/screens/tasks/tasks_create.dart
@@ -1,179 +1,44 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:intl/intl.dart';
 import 'package:uuid/uuid.dart';
 
 import 'package:board/models/task_model.dart';
+import 'package:board/components/tasks/task_form.dart';
 import 'package:board/providers/board_route_delegate_provider.dart';
 import 'package:board/providers/tasks_provider.dart';
 
 class TasksCreateScreen extends HookConsumerWidget {
-  TasksCreateScreen({
+  const TasksCreateScreen({
     Key? key,
   }) : super(key: key);
 
-  final formKey = GlobalKey<FormState>();
-  final formatter = DateFormat('yyyy-MM-dd');
-
-  Future<DateTime?> openDatePikcer(BuildContext context, DateTime date) {
-    return showDatePicker(
-      context: context,
-      initialDate: date,
-      firstDate: DateTime(2020),
-      lastDate: DateTime(2021),
-    );
-  }
-
-  Color? statusColor(String status) {
-    if (status == taskStatusTodo) {
-      return Colors.lime[100];
-    }
-
-    if (status == taskStatusDone) {
-      return Colors.brown[100];
-    }
-
-    return Colors.amber;
+  void create(WidgetRef ref, TaskModel task) {
+    ref.read(tasksProvider.notifier).add(task);
+    ref.read(boardRouteDelegateProvider.notifier).setModeToList();
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final titleEditingController = useTextEditingController(text: '');
-    final desciptionEditingController = useTextEditingController(text: '');
-    final dateEditingController =
-        useTextEditingController(text: formatter.format(DateTime.now()));
-    final statusDropDownValue = useState(taskStatusTodo);
-
     return Scaffold(
       appBar: AppBar(
         title: const Text('タスク作成'),
       ),
-      body: Form(
-        key: formKey,
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                margin: const EdgeInsets.only(bottom: 16.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    TextFormField(
-                      controller: titleEditingController,
-                      maxLength: 12,
-                      decoration:
-                          const InputDecoration(hintText: 'タイトルを入力しましょう'),
-                      keyboardType: TextInputType.text,
-                      validator: (value) {
-                        if (value!.isEmpty) return 'タイトルは必須項目です';
-                        if (value.length > 12) return 'タイトルは12文字以内で入力してください';
-                      },
-                    ),
-                    TextFormField(
-                      controller: desciptionEditingController,
-                      decoration:
-                          const InputDecoration(hintText: '説明文を入力しましょう'),
-                      keyboardType: TextInputType.text,
-                      maxLength: 50,
-                      validator: (value) {
-                        if (value!.isEmpty) return '説明文は必須項目です';
-                        if (value.length > 50) return '説明文は50文字以内で入力してください';
-                      },
-                    ),
-                    DropdownButton(
-                      value: statusDropDownValue.value,
-                      icon: const Icon(Icons.arrow_downward),
-                      iconSize: 24,
-                      elevation: 16,
-                      onChanged: (String? newValue) {
-                        statusDropDownValue.value = newValue ?? 'TODO';
-                      },
-                      items: [taskStatusTodo, taskStatusDoing, taskStatusDone]
-                          .map<DropdownMenuItem<String>>(
-                        (String value) {
-                          return DropdownMenuItem<String>(
-                            value: value,
-                            child: Container(
-                              padding: const EdgeInsets.all(8.0),
-                              decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(10),
-                                color: statusColor(value),
-                              ),
-                              child: Text(value),
-                            ),
-                          );
-                        },
-                      ).toList(),
-                    ),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: TextFormField(
-                            readOnly: true,
-                            controller: dateEditingController,
-                          ),
-                        ),
-                        Container(
-                          margin: const EdgeInsets.only(left: 8.0),
-                          width: 96,
-                          child: ElevatedButton(
-                            child: const Text('日付設定'),
-                            onPressed: () async {
-                              final result = await openDatePikcer(
-                                context,
-                                DateTime.now(),
-                              );
+      body: HookBuilder(
+        builder: (context) {
+          return TaskForm(
+            taskId: const Uuid().v4(),
+            title: '',
+            description: '',
+            dueDateTime: DateTime.now(),
+            status: taskStatusTodo,
+            onSaveTapped: (TaskModel newTask) {
+              create(ref, newTask);
 
-                              if (result == null) {
-                                return;
-                              }
-
-                              final formatted = formatter.format(result);
-
-                              dateEditingController.text = formatted;
-                            },
-                          ),
-                        ),
-                      ],
-                    )
-                  ],
-                ),
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  ElevatedButton(
-                    child: const Text('保存'),
-                    onPressed: () {
-                      final result = formKey.currentState!.validate();
-                      if (!result) {
-                        return;
-                      }
-
-                      ref.read(tasksProvider.notifier).add(
-                            TaskModel(
-                              id: const Uuid().v4(),
-                              title: titleEditingController.text,
-                              description: desciptionEditingController.text,
-                              dueDateTime:
-                                  DateTime.parse(dateEditingController.text),
-                              status: statusDropDownValue.value,
-                            ),
-                          );
-
-                      ref
-                          .read(boardRouteDelegateProvider.notifier)
-                          .setModeToList();
-                    },
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
+              ref.read(boardRouteDelegateProvider.notifier).setModeToList();
+            },
+          );
+        },
       ),
     );
   }

--- a/lib/screens/tasks/tasks_detail.dart
+++ b/lib/screens/tasks/tasks_detail.dart
@@ -1,40 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:intl/intl.dart';
 
 import 'package:board/models/task_model.dart';
 import 'package:board/providers/board_route_delegate_provider.dart';
 import 'package:board/providers/task_detail_provider.dart';
 import 'package:board/providers/tasks_provider.dart';
+import 'package:board/components/tasks/task_form.dart';
 
 class TasksDetailScreen extends HookConsumerWidget {
-  TasksDetailScreen({
+  const TasksDetailScreen({
     Key? key,
   }) : super(key: key);
 
-  final formKey = GlobalKey<FormState>();
-  final formatter = DateFormat('yyyy-MM-dd');
-
-  Future<DateTime?> openDatePikcer(BuildContext context, DateTime date) {
-    return showDatePicker(
-      context: context,
-      initialDate: date,
-      firstDate: DateTime(2021),
-      lastDate: DateTime(2022),
-    );
-  }
-
-  Color? statusColor(String status) {
-    if (status == taskStatusTodo) {
-      return Colors.lime[100];
-    }
-
-    if (status == taskStatusDone) {
-      return Colors.brown[100];
-    }
-
-    return Colors.amber;
+  void update(
+    WidgetRef ref,
+    String taskId,
+    String previousTaskStatus,
+    TaskModel task,
+  ) {
+    ref.read(tasksProvider.notifier).edit(taskId, previousTaskStatus, task);
+    ref.read(boardRouteDelegateProvider.notifier).setModeToList();
   }
 
   @override
@@ -61,151 +47,17 @@ class TasksDetailScreen extends HookConsumerWidget {
             return const CircularProgressIndicator();
           }
 
-          final titleEditingController =
-              useTextEditingController(text: task.title);
-          final desciptionEditingController =
-              useTextEditingController(text: task.description);
-          final dateEditingController = useTextEditingController(
-              text: formatter.format(task.dueDateTime));
+          return TaskForm(
+            taskId: task.id,
+            title: task.title,
+            description: task.description,
+            dueDateTime: task.dueDateTime,
+            status: task.status,
+            onSaveTapped: (TaskModel newTask) {
+              update(ref, taskId, task.status, newTask);
 
-          final statusDropDownValue = useState(task.status);
-
-          return Form(
-            key: formKey,
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Container(
-                    margin: const EdgeInsets.only(bottom: 16.0),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        TextFormField(
-                          controller: titleEditingController,
-                          maxLength: 12,
-                          decoration:
-                              const InputDecoration(hintText: 'タイトルを入力しましょう'),
-                          keyboardType: TextInputType.text,
-                          validator: (value) {
-                            if (value!.isEmpty) {
-                              return 'タイトルは必須項目です';
-                            } else if (value.length > 12) {
-                              return 'タイトルは12文字以内で入力してください';
-                            }
-                          },
-                        ),
-                        TextFormField(
-                          controller: desciptionEditingController,
-                          decoration:
-                              const InputDecoration(hintText: '説明文を入力しましょう'),
-                          keyboardType: TextInputType.text,
-                          maxLength: 50,
-                          validator: (value) {
-                            if (value!.isEmpty) return '説明文は必須項目です';
-                            if (value.length > 50) return '説明文は50文字以内で入力してください';
-                          },
-                        ),
-                        DropdownButton(
-                          value: statusDropDownValue.value,
-                          icon: const Icon(Icons.arrow_downward),
-                          iconSize: 24,
-                          elevation: 16,
-                          onChanged: (String? newValue) {
-                            statusDropDownValue.value = newValue ?? 'TODO';
-                          },
-                          items: [
-                            taskStatusTodo,
-                            taskStatusDoing,
-                            taskStatusDone
-                          ].map<DropdownMenuItem<String>>(
-                            (String value) {
-                              return DropdownMenuItem<String>(
-                                value: value,
-                                child: Container(
-                                  padding: const EdgeInsets.all(8.0),
-                                  decoration: BoxDecoration(
-                                    borderRadius: BorderRadius.circular(10),
-                                    color: statusColor(value),
-                                  ),
-                                  child: Text(value),
-                                ),
-                              );
-                            },
-                          ).toList(),
-                        ),
-                        Row(
-                          children: [
-                            Expanded(
-                              child: TextFormField(
-                                readOnly: true,
-                                controller: dateEditingController,
-                              ),
-                            ),
-                            Container(
-                              margin: const EdgeInsets.only(left: 8.0),
-                              width: 96,
-                              child: ElevatedButton(
-                                child: const Text('日付設定'),
-                                onPressed: () async {
-                                  final result = await openDatePikcer(
-                                    context,
-                                    DateTime.now(),
-                                  );
-
-                                  if (result == null) {
-                                    return;
-                                  }
-
-                                  final formatted = formatter.format(result);
-
-                                  dateEditingController.text = formatted;
-                                },
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [
-                      ElevatedButton(
-                        child: const Text('保存'),
-                        onPressed: () {
-                          final result = formKey.currentState!.validate();
-                          if (!result) {
-                            return;
-                          }
-
-                          final updatedTask = TaskModel(
-                            id: task.id,
-                            title: titleEditingController.text,
-                            description: desciptionEditingController.text,
-                            dueDateTime: DateTime.parse(
-                              dateEditingController.text,
-                            ),
-                            status: statusDropDownValue.value,
-                          );
-
-                          task.setId(taskId);
-
-                          ref
-                              .read(tasksProvider.notifier)
-                              .edit(taskId, task.status, updatedTask);
-
-                          ref
-                              .read(boardRouteDelegateProvider.notifier)
-                              .setModeToList();
-                        },
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
+              ref.read(boardRouteDelegateProvider.notifier).setModeToList();
+            },
           );
         },
       ),

--- a/lib/viewmodels/task_list_change_notifier.dart
+++ b/lib/viewmodels/task_list_change_notifier.dart
@@ -16,7 +16,9 @@ class TaskListChangeNotifier extends StateNotifier<List<TaskModel>> {
 
   Future<void> add(TaskModel task) async {
     return repository.create(task).then((value) {
-      state = [...state, value];
+      return repository.findByStatus(task.status);
+    }).then((newList) {
+      state = [...newList];
     }).catchError((dynamic error) {});
   }
 


### PR DESCRIPTION
## WHY
 - タスク作成画面と詳細画面で同じような処理が書かれてあったので、共通化を図る。

## WHAT
 - 保存ボタンをタップしたときの処理だけ違うので、それ以外は `task_form.dart` widgetに移す。保存ボタンタップ時の処理はコールバックとして処理をwidgetに渡すように。 3b91814
 - setIdの処理はもう使わなくなったので、削除 dd1f09d
 - 作成したタスクの同じステータスのものを取得するように dd1f09d