### PR TITLE
riverpodのnotifierでreadの代わりにwatchを使う

### DIFF
--- a/lib/components/tasks/task_card.dart
+++ b/lib/components/tasks/task_card.dart
@@ -99,7 +99,7 @@ class TaskCard extends ConsumerWidget {
                 ElevatedButton(
                   child: const Text('詳細へ'),
                   onPressed: () {
-                    ref.read(boardRouteDelegateProvider).setModeToDetails(id);
+                    ref.watch(boardRouteDelegateProvider).setModeToDetails(id);
                   },
                 ),
               ],

--- a/lib/components/tasks/tasks_doing_list.dart
+++ b/lib/components/tasks/tasks_doing_list.dart
@@ -14,7 +14,7 @@ class TasksDoingList extends ConsumerWidget {
 
     return RefreshIndicator(
       onRefresh: () {
-        return ref.read(tasksProvider.notifier).findByStatus(taskStatusDoing);
+        return ref.watch(tasksProvider.notifier).findByStatus(taskStatusDoing);
       },
       child: tasks.isEmpty
           ? const Center(

--- a/lib/components/tasks/tasks_done_list.dart
+++ b/lib/components/tasks/tasks_done_list.dart
@@ -14,7 +14,7 @@ class TasksDoneList extends ConsumerWidget {
 
     return RefreshIndicator(
       onRefresh: () {
-        return ref.read(tasksProvider.notifier).findByStatus(taskStatusDone);
+        return ref.watch(tasksProvider.notifier).findByStatus(taskStatusDone);
       },
       child: tasks.isEmpty
           ? const Center(

--- a/lib/components/tasks/tasks_todo_list.dart
+++ b/lib/components/tasks/tasks_todo_list.dart
@@ -14,7 +14,7 @@ class TasksTodoList extends ConsumerWidget {
 
     return RefreshIndicator(
       onRefresh: () {
-        return ref.read(tasksProvider.notifier).findByStatus(taskStatusTodo);
+        return ref.watch(tasksProvider.notifier).findByStatus(taskStatusTodo);
       },
       child: tasks.isEmpty
           ? const Center(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,7 @@ class MyApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final provider = ref.read(boardRouteDelegateProvider);
+    final provider = ref.watch(boardRouteDelegateProvider);
 
     return MaterialApp.router(
       title: 'Board App',

--- a/lib/screens/board_home_screen.dart
+++ b/lib/screens/board_home_screen.dart
@@ -24,7 +24,7 @@ class BoardHomeScreen extends ConsumerWidget {
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: tappedTabIndex,
         onTap: (int index) {
-          ref.read(tabProvider.notifier).changeTab(index);
+          ref.watch(tabProvider.notifier).changeTab(index);
         },
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.task), label: 'タスク'),

--- a/lib/screens/tasks/tasks_create.dart
+++ b/lib/screens/tasks/tasks_create.dart
@@ -14,8 +14,8 @@ class TasksCreateScreen extends HookConsumerWidget {
   }) : super(key: key);
 
   void create(WidgetRef ref, TaskModel task) {
-    ref.read(tasksProvider.notifier).add(task);
-    ref.read(boardRouteDelegateProvider.notifier).setModeToList();
+    ref.watch(tasksProvider.notifier).add(task);
+    ref.watch(boardRouteDelegateProvider.notifier).setModeToList();
   }
 
   @override
@@ -35,7 +35,7 @@ class TasksCreateScreen extends HookConsumerWidget {
             onSaveTapped: (TaskModel newTask) {
               create(ref, newTask);
 
-              ref.read(boardRouteDelegateProvider.notifier).setModeToList();
+              ref.watch(boardRouteDelegateProvider.notifier).setModeToList();
             },
           );
         },

--- a/lib/screens/tasks/tasks_detail.dart
+++ b/lib/screens/tasks/tasks_detail.dart
@@ -19,13 +19,13 @@ class TasksDetailScreen extends HookConsumerWidget {
     String previousTaskStatus,
     TaskModel task,
   ) {
-    ref.read(tasksProvider.notifier).edit(taskId, previousTaskStatus, task);
-    ref.read(boardRouteDelegateProvider.notifier).setModeToList();
+    ref.watch(tasksProvider.notifier).edit(taskId, previousTaskStatus, task);
+    ref.watch(boardRouteDelegateProvider.notifier).setModeToList();
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final delegate = ref.read(boardRouteDelegateProvider);
+    final delegate = ref.watch(boardRouteDelegateProvider);
 
     final taskId = delegate.selectedTaskId ?? '';
 
@@ -37,7 +37,7 @@ class TasksDetailScreen extends HookConsumerWidget {
         builder: (context) {
           useFuture(
             useMemoized(
-              () => ref.read(taskDetailProvider.notifier).findById(taskId),
+              () => ref.watch(taskDetailProvider.notifier).findById(taskId),
               [taskId],
             ),
           );
@@ -56,7 +56,7 @@ class TasksDetailScreen extends HookConsumerWidget {
             onSaveTapped: (TaskModel newTask) {
               update(ref, taskId, task.status, newTask);
 
-              ref.read(boardRouteDelegateProvider.notifier).setModeToList();
+              ref.watch(boardRouteDelegateProvider.notifier).setModeToList();
             },
           );
         },

--- a/lib/screens/tasks/tasks_index.dart
+++ b/lib/screens/tasks/tasks_index.dart
@@ -43,7 +43,7 @@ class TasksIndexScreen extends HookConsumerWidget {
         status = taskStatusDone;
       }
 
-      ref.read(tasksProvider.notifier).findByStatus(status);
+      ref.watch(tasksProvider.notifier).findByStatus(status);
     });
 
     return Scaffold(
@@ -52,7 +52,7 @@ class TasksIndexScreen extends HookConsumerWidget {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          ref.read(boardRouteDelegateProvider).setModeToCreate();
+          ref.watch(boardRouteDelegateProvider).setModeToCreate();
         },
         tooltip: 'Increment',
         child: const Icon(Icons.add),
@@ -80,7 +80,7 @@ class TasksIndexScreen extends HookConsumerWidget {
                     status = taskStatusDone;
                   }
 
-                  ref.read(tasksProvider.notifier).findByStatus(status);
+                  ref.watch(tasksProvider.notifier).findByStatus(status);
                 },
                 tabs: taskStatusTabs.map((TaskStatusTabModel taskStatusTab) {
                   return Tab(
@@ -94,7 +94,7 @@ class TasksIndexScreen extends HookConsumerWidget {
                 final snapshot = useFuture(
                   useMemoized(
                     () => ref
-                        .read(tasksProvider.notifier)
+                        .watch(tasksProvider.notifier)
                         .findByStatus(taskStatusTodo),
                     [
                       tasksProvider.toString(),


### PR DESCRIPTION
## WHY
 - riverpodについてのドキュメントを読んでいたら、リビルドを避けるための `ref.read` は `ref.watch` で代用できるみたいなので、`ref.read` の代わりに `ref.watch` を書いていく。
   - ```
     But I wanted to use ref.read to reduce the number of times my widget rebuild
     While the goal is commendable, it is important to note that you can achieve the exact same effect (reducing the number of builds) using ref.watch instead.
      ```
    - ```
      Using ref.read should be avoided as much as possible.
       ```
    - https://riverpod.dev/docs/concepts/reading/#using-refread-to-obtain-the-state-of-a-provider-once