### PR TITLE
タスク作成更新の後指定したタスクタブに遷移するように

### DIFF
--- a/lib/providers/bottom_tab_provider.dart
+++ b/lib/providers/bottom_tab_provider.dart
@@ -1,0 +1,7 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:board/viewmodels/bottom_tab_change_notifier.dart';
+
+final tabProvider = StateNotifierProvider<BottomTabChangeNotifier, int>(
+  (ref) => BottomTabChangeNotifier(),
+);

--- a/lib/providers/tab_provider.dart
+++ b/lib/providers/tab_provider.dart
@@ -1,6 +1,0 @@
-import 'package:hooks_riverpod/hooks_riverpod.dart';
-
-import 'package:board/viewmodels/tab_change_notifier.dart';
-
-final tabProvider =
-    StateNotifierProvider<TabChangeNotifier, int>((ref) => TabChangeNotifier());

--- a/lib/providers/task_tab_provider.dart
+++ b/lib/providers/task_tab_provider.dart
@@ -1,0 +1,7 @@
+import 'package:board/viewmodels/task_status_tab_change_notifier.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final taskTabChangeProvider =
+    StateNotifierProvider<TaskStatusTabChangeNotifier, int>(
+  (ref) => TaskStatusTabChangeNotifier(),
+);

--- a/lib/providers/tasks_provider.dart
+++ b/lib/providers/tasks_provider.dart
@@ -7,6 +7,8 @@ import 'package:board/infra/sqlite/init.dart';
 
 final tasksProvider =
     StateNotifierProvider<TaskListChangeNotifier, List<TaskModel>>(
-  (ref) =>
-      TaskListChangeNotifier(repository: TaskSqlite(client: SqliteClient())),
+  (ref) => TaskListChangeNotifier(
+    repository: TaskSqlite(client: SqliteClient()),
+    ref: ref,
+  ),
 );

--- a/lib/screens/board_home_screen.dart
+++ b/lib/screens/board_home_screen.dart
@@ -3,7 +3,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'package:board/screens/tasks/tasks_index.dart';
 import 'package:board/screens/settings/settings_index.dart';
-import 'package:board/providers/tab_provider.dart';
+import 'package:board/providers/bottom_tab_provider.dart';
 
 class BoardHomeScreen extends ConsumerWidget {
   BoardHomeScreen({

--- a/lib/screens/tasks/tasks_detail.dart
+++ b/lib/screens/tasks/tasks_detail.dart
@@ -16,10 +16,9 @@ class TasksDetailScreen extends HookConsumerWidget {
   void update(
     WidgetRef ref,
     String taskId,
-    String previousTaskStatus,
     TaskModel task,
   ) {
-    ref.watch(tasksProvider.notifier).edit(taskId, previousTaskStatus, task);
+    ref.watch(tasksProvider.notifier).edit(taskId, task);
     ref.watch(boardRouteDelegateProvider.notifier).setModeToList();
   }
 
@@ -54,7 +53,7 @@ class TasksDetailScreen extends HookConsumerWidget {
             dueDateTime: task.dueDateTime,
             status: task.status,
             onSaveTapped: (TaskModel newTask) {
-              update(ref, taskId, task.status, newTask);
+              update(ref, taskId, newTask);
 
               ref.watch(boardRouteDelegateProvider.notifier).setModeToList();
             },

--- a/lib/screens/tasks/tasks_index.dart
+++ b/lib/screens/tasks/tasks_index.dart
@@ -8,6 +8,7 @@ import 'package:board/components/tasks/tasks_doing_list.dart';
 import 'package:board/components/tasks/tasks_done_list.dart';
 import 'package:board/providers/board_route_delegate_provider.dart';
 import 'package:board/providers/tasks_provider.dart';
+import 'package:board/providers/task_tab_provider.dart';
 
 class TaskStatusTabModel {
   const TaskStatusTabModel({required this.title, required this.icon});
@@ -27,10 +28,12 @@ class TasksIndexScreen extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final taskStatusTab = ref.watch(taskTabChangeProvider);
+
     final tabController = useTabController(
       initialLength: taskStatusTabs.length,
     );
-
+    tabController.animateTo(taskStatusTab);
     tabController.addListener(() {
       if (tabController.indexIsChanging) {
         return;

--- a/lib/viewmodels/bottom_tab_change_notifier.dart
+++ b/lib/viewmodels/bottom_tab_change_notifier.dart
@@ -1,7 +1,7 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class TabChangeNotifier extends StateNotifier<int> {
-  TabChangeNotifier() : super(_initialTab);
+class BottomTabChangeNotifier extends StateNotifier<int> {
+  BottomTabChangeNotifier() : super(_initialTab);
 
   static const _initialTab = 0;
 

--- a/lib/viewmodels/task_list_change_notifier.dart
+++ b/lib/viewmodels/task_list_change_notifier.dart
@@ -2,11 +2,14 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'package:board/repositories/task_repository.dart';
 import 'package:board/models/task_model.dart';
+import 'package:board/providers/task_tab_provider.dart';
 
 class TaskListChangeNotifier extends StateNotifier<List<TaskModel>> {
-  TaskListChangeNotifier({required this.repository}) : super([]);
+  TaskListChangeNotifier({required this.repository, required this.ref})
+      : super([]);
 
   final TaskRepository repository;
+  final StateNotifierProviderRef<TaskListChangeNotifier, List<TaskModel>> ref;
 
   Future<void> findByStatus(String status) async {
     return repository.findByStatus(status).then((value) {
@@ -18,18 +21,19 @@ class TaskListChangeNotifier extends StateNotifier<List<TaskModel>> {
     return repository.create(task).then((value) {
       return repository.findByStatus(task.status);
     }).then((newList) {
+      ref.watch(taskTabChangeProvider.notifier).changeTab(task.status);
       state = [...newList];
     }).catchError((dynamic error) {});
   }
 
   Future<void> edit(
     String taskId,
-    String previousTaskStatus,
     TaskModel taskModel,
   ) async {
     return repository.update(taskId, taskModel).then((value) {
-      return repository.findByStatus(previousTaskStatus);
+      return repository.findByStatus(taskModel.status);
     }).then((newList) {
+      ref.watch(taskTabChangeProvider.notifier).changeTab(taskModel.status);
       state = [...newList];
     }).catchError((dynamic error) {});
   }

--- a/lib/viewmodels/task_status_tab_change_notifier.dart
+++ b/lib/viewmodels/task_status_tab_change_notifier.dart
@@ -1,0 +1,19 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:board/models/task_model.dart';
+
+class TaskStatusTabChangeNotifier extends StateNotifier<int> {
+  TaskStatusTabChangeNotifier() : super(_initialTaskTab);
+
+  static const _initialTaskTab = 0;
+
+  void changeTab(String tapped) {
+    if (tapped == taskStatusDoing) {
+      state = 1;
+    } else if (tapped == taskStatusDone) {
+      state = 2;
+    } else {
+      state = 0;
+    }
+  }
+}


### PR DESCRIPTION
## WHY
 - タスクを作成したり更新した後に、指定したタブがそのタスクのステータスになっておらずずっとTODOで固定になっており、リストにあるタスクのステータスと違う問題があった。これにより、DOINGのタスクを作ったあと、TODOのタブにいてDOINGのタスクが一覧になるという形になっていた。
 - その問題を直すため、作成したあとは作成したときに指定したステータスのタブに遷移するようにする。更新したときは更新するのに指定したタブに遷移する。

## WHAT
 - bottom tabとタスクのステータスタブがややこしくなるので、既存にあった tabをbottom tabに名前を変更する。 7cd201f
 - useTabControllerから取得できる tabControllerに `animateTo` というメソッドがあるので、それに渡す値をprovider管理し、指定したタスクのタブに遷移する。 cb9e37a